### PR TITLE
GH-47 Consume output from opa when executing opa test

### DIFF
--- a/src/main/java/com/bisnode/opa/StartOpaTask.java
+++ b/src/main/java/com/bisnode/opa/StartOpaTask.java
@@ -80,7 +80,7 @@ public class StartOpaTask extends DefaultTask {
 
         new Thread(() -> {
             String line;
-            while ((line = outputConsumer.read()) != null) {
+            while ((line = outputConsumer.readLine()) != null) {
                 if (line.contains("Initializing server")) {
                     serverInitializationLatch.countDown();
                 }

--- a/src/main/java/com/bisnode/opa/process/OpaOutputConsumer.java
+++ b/src/main/java/com/bisnode/opa/process/OpaOutputConsumer.java
@@ -6,30 +6,31 @@ import org.gradle.api.logging.Logging;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+// GH-47
 public class OpaOutputConsumer {
 
-    public static final String POISON_PILL = "DONE_CONSUMING_OUTPUT";
+    private static final String POISON_PILL = "DONE_CONSUMING_OUTPUT";
     private static final Logger log = Logging.getLogger(OpaOutputConsumer.class);
 
     private final Process opaProcess;
+    private final BlockingQueue<String> outputFromProcess;
 
     public OpaOutputConsumer(Process opaProcess) {
         this.opaProcess = opaProcess;
+        this.outputFromProcess = new LinkedBlockingQueue<>();
     }
 
     /**
      * Consumes OPA output in another thread and enqueues each consumed line into a queue.
-     * If there's nothing left to be consumed, enqueues a {@value #POISON_PILL}
-     *
-     * @return A queue that will be enqueued with each consumed line from OPA, and finalised by a {@value #POISON_PILL}
      */
-    public BlockingQueue<String> spawn() {
-        LinkedBlockingQueue<String> outputFromProcess = new LinkedBlockingQueue<>();
+    public void spawn() {
         new Thread(() -> {
             try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(this.opaProcess.getInputStream(), UTF_8))) {
                 String line;
@@ -42,10 +43,41 @@ public class OpaOutputConsumer {
                     log.warn("IOException while reading OPA's stdout", e);
                 }
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                log.error("Unable to read from OPA's stdout", e);
             }
         }).start();
-        return outputFromProcess;
+    }
+
+    /**
+     * Reads the next output line from OPA
+     *
+     * @return Next output line from OPA, or null if there's no more output
+     */
+    public String read() {
+        try {
+            String line = outputFromProcess.take();
+            if (line.equals(POISON_PILL)) {
+                return null;
+            }
+            return line;
+        } catch (InterruptedException e) {
+            log.error("Unable to read from OPA output buffer", e);
+        }
+        return null;
+    }
+
+    /**
+     * Reads all output line from OPA, blocks until the OPA process ends the stream
+     *
+     * @return All outputs lines from OPA
+     */
+    public List<String> readAll() {
+        List<String> allOutput = new ArrayList<>();
+        String line;
+        while ((line = read()) != null) {
+            allOutput.add(line);
+        }
+        return allOutput;
     }
 
 }

--- a/src/main/java/com/bisnode/opa/process/OpaOutputConsumer.java
+++ b/src/main/java/com/bisnode/opa/process/OpaOutputConsumer.java
@@ -53,7 +53,7 @@ public class OpaOutputConsumer {
      *
      * @return Next output line from OPA, or null if there's no more output
      */
-    public String read() {
+    public String readLine() {
         try {
             String line = outputFromProcess.take();
             if (line.equals(POISON_PILL)) {
@@ -71,10 +71,10 @@ public class OpaOutputConsumer {
      *
      * @return All outputs lines from OPA
      */
-    public List<String> readAll() {
+    public List<String> readAllLines() {
         List<String> allOutput = new ArrayList<>();
         String line;
-        while ((line = read()) != null) {
+        while ((line = readLine()) != null) {
             allOutput.add(line);
         }
         return allOutput;

--- a/src/main/java/com/bisnode/opa/process/OpaOutputConsumer.java
+++ b/src/main/java/com/bisnode/opa/process/OpaOutputConsumer.java
@@ -1,0 +1,51 @@
+package com.bisnode.opa.process;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class OpaOutputConsumer {
+
+    public static final String POISON_PILL = "DONE_CONSUMING_OUTPUT";
+    private static final Logger log = Logging.getLogger(OpaOutputConsumer.class);
+
+    private final Process opaProcess;
+
+    public OpaOutputConsumer(Process opaProcess) {
+        this.opaProcess = opaProcess;
+    }
+
+    /**
+     * Consumes OPA output in another thread and enqueues each consumed line into a queue.
+     * If there's nothing left to be consumed, enqueues a {@value #POISON_PILL}
+     *
+     * @return A queue that will be enqueued with each consumed line from OPA, and finalised by a {@value #POISON_PILL}
+     */
+    public BlockingQueue<String> spawn() {
+        LinkedBlockingQueue<String> outputFromProcess = new LinkedBlockingQueue<>();
+        new Thread(() -> {
+            try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(this.opaProcess.getInputStream(), UTF_8))) {
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    outputFromProcess.put(line);
+                }
+                outputFromProcess.put(POISON_PILL);
+            } catch (IOException e) {
+                if (!"Stream closed".equals(e.getMessage())) {
+                    log.warn("IOException while reading OPA's stdout", e);
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }).start();
+        return outputFromProcess;
+    }
+
+}

--- a/src/main/java/com/bisnode/opa/process/OpaTestProcess.java
+++ b/src/main/java/com/bisnode/opa/process/OpaTestProcess.java
@@ -25,7 +25,7 @@ public class OpaTestProcess {
 
             OpaOutputConsumer opaOutputConsumer = new OpaOutputConsumer(process);
             opaOutputConsumer.spawn();
-            String testResultFromOpa = opaOutputConsumer.readAll().stream().collect(Collectors.joining());
+            String testResultFromOpa = opaOutputConsumer.readAllLines().stream().collect(Collectors.joining());
             int exitCode = process.waitFor();
             return new ProcessExecutionResult(testResultFromOpa, exitCode);
         } catch (IOException | InterruptedException e) {

--- a/src/main/java/com/bisnode/opa/process/OpaTestProcess.java
+++ b/src/main/java/com/bisnode/opa/process/OpaTestProcess.java
@@ -4,15 +4,9 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.tooling.TestExecutionException;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import java.util.concurrent.BlockingQueue;
 
 public class OpaTestProcess {
 
@@ -33,33 +27,27 @@ public class OpaTestProcess {
                     .command(command.getCommandArgs())
                     .start();
 
-            Future<String> resultFromOpa = spawnOutputConsumerThread(process);
+            OpaOutputConsumer opaOutputConsumer = new OpaOutputConsumer(process);
+            String testResultFromOpa = compileOpaOutput(opaOutputConsumer);
             int exitCode = process.waitFor();
             // Should only retrieve results after OPA process exits
-            String result = resultFromOpa.get();
-            return new ProcessExecutionResult(result, exitCode);
-        } catch (IOException | InterruptedException | ExecutionException e) {
+            return new ProcessExecutionResult(testResultFromOpa, exitCode);
+        } catch (IOException | InterruptedException e) {
             throw new TestExecutionException("Failed to start OPA process for tests", e);
         }
     }
 
-    private Future<String> spawnOutputConsumerThread(Process process) {
-        CompletableFuture<String> outputFromProcess = new CompletableFuture<>();
-        new Thread(() -> {
-            try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
-                StringBuilder resultStr = new StringBuilder();
-                String line;
-                while ((line = bufferedReader.readLine()) != null) {
-                    resultStr.append(line);
-                }
-                log.debug("[OPA] {}", resultStr);
-                outputFromProcess.complete(resultStr.toString());
-
-            } catch (IOException e) {
-                log.error("IOException while reading OPA's test results", e);
+    private String compileOpaOutput(OpaOutputConsumer opaOutputConsumer) {
+        BlockingQueue<String> outputFromOpa = opaOutputConsumer.spawn();
+        StringBuilder compiledOutputStr = new StringBuilder();
+        try {
+            String line;
+            while (!(line = outputFromOpa.take()).equals(OpaOutputConsumer.POISON_PILL)) {
+                compiledOutputStr.append(line);
             }
-        }).start();
-        return outputFromProcess;
+        } catch (InterruptedException e) {
+            log.error("Failed to read from consumed output from OPA");
+        }
+        return compiledOutputStr.toString();
     }
-
 }

--- a/src/test/java/com/bisnode/opa/OpaIOTest.java
+++ b/src/test/java/com/bisnode/opa/OpaIOTest.java
@@ -17,9 +17,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OpaIOTest {
     private Project project;
@@ -37,7 +35,7 @@ public class OpaIOTest {
 
     //GH-28
     @Test
-    void shouldNotHangOnOPAOutputBufferOverflow() throws IOException, InterruptedException {
+    void shouldNotHangOnOPAOutputBufferOverflow() throws IOException {
         //given
         OpaPluginConvention convention = project.getConvention().getPlugin(OpaPluginConvention.class);
         convention.setSrcDir(getPathToTmpFolder());

--- a/src/test/java/com/bisnode/opa/OpaIOTest.java
+++ b/src/test/java/com/bisnode/opa/OpaIOTest.java
@@ -19,6 +19,7 @@ import java.io.InputStreamReader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+
 public class OpaIOTest {
     private Project project;
 

--- a/src/test/java/com/bisnode/opa/OpaPluginTestUtils.java
+++ b/src/test/java/com/bisnode/opa/OpaPluginTestUtils.java
@@ -19,4 +19,16 @@ final class OpaPluginTestUtils {
                 "}";
     }
 
+    static String getManyRegoPolicyTests() {
+        StringBuilder regoTestsBuilder = new StringBuilder();
+        for(int i = 0; i < 300; i++) {
+            regoTestsBuilder.append("\n");
+            regoTestsBuilder.append("test_allow_is_false_" + i + " {\n");
+            regoTestsBuilder.append("    not allow\n");
+            regoTestsBuilder.append("}");
+        }
+
+        return "package test\n" + regoTestsBuilder;
+    }
+
 }


### PR DESCRIPTION
The problem was caused by unconsumed output from OPA during `opa test`. The solution is similar to #29, where we spawn a thread to consume the output from the OPA process.

Also included a test for this bug.

Open to feedback!