### PR TITLE
Resolve OPA executable from PATH unless provided

### DIFF
--- a/src/main/java/com/bisnode/opa/configuration/Environment.java
+++ b/src/main/java/com/bisnode/opa/configuration/Environment.java
@@ -1,0 +1,22 @@
+package com.bisnode.opa.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class Environment {
+
+    private static final Map<String, String> environment;
+    static {
+        environment = new HashMap<>(System.getenv());
+    }
+
+    public static void put(String key, String value) {
+        environment.put(key, value);
+    }
+
+    public static Optional<String> get(String key) {
+        return Optional.ofNullable(environment.get(key));
+    }
+
+}

--- a/src/test/java/com/bisnode/opa/configuration/DefaultOpaConfigurationTest.java
+++ b/src/test/java/com/bisnode/opa/configuration/DefaultOpaConfigurationTest.java
@@ -3,8 +3,14 @@ package com.bisnode.opa.configuration;
 import org.gradle.api.Project;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,6 +18,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DefaultOpaConfigurationTest {
 
     private Project project;
+
+    @TempDir
+    static Path opaPath;
+    static Path opaFile;
+
+    @BeforeAll
+    public static void init() throws IOException {
+        opaFile = Files.createFile(opaPath.resolve("opa"));
+    }
 
     @BeforeEach
     public void before() {
@@ -24,16 +39,25 @@ public class DefaultOpaConfigurationTest {
         DefaultOpaPluginConvention pluginConvention = new DefaultOpaPluginConvention(project);
         DefaultOpaConfiguration configuration = new DefaultOpaConfiguration(pluginConvention);
 
-        configuration.setLocation("/tmp/location");
+        configuration.setLocation("/tmp/location/opa");
         configuration.setSrcDir("/tmp/src");
         configuration.setTestDir("/tmp/test");
 
-        assertEquals("/tmp/location", configuration.getLocation());
+        assertEquals("/tmp/location/opa", configuration.getLocation());
         assertEquals("/tmp/src", configuration.getSrcDir());
         assertEquals("/tmp/test", configuration.getTestDir());
 
         assertEquals(TypeOf.typeOf(OpaPluginConvention.class), pluginConvention.getPublicType());
         assertTrue(pluginConvention.toString().startsWith("DefaultOpaPluginConvention{"));
+    }
+
+    @Test
+    public void notProvidingLocationSearchesPathForBinary() {
+        Environment.put("PATH", opaPath.toString());
+        DefaultOpaPluginConvention pluginConvention = new DefaultOpaPluginConvention(project);
+        DefaultOpaConfiguration configuration = new DefaultOpaConfiguration(pluginConvention);
+
+        assertEquals(opaFile.toString(), configuration.getLocation());
     }
 
 }


### PR DESCRIPTION
This was the documented behavior, although in reality the default would
be to just use "opa" as the command, presumably from the current
working directory. This fix scans the $PATH for an executable named
"opa" and uses that, unless a location has been provided in the
plugin configuration.

Signed-off-by: Anders Eknert <anders@eknert.com>