### PR TITLE
Write opa coverage report to the project's build directory

### DIFF
--- a/src/main/java/com/bisnode/opa/TestRegoCoverageTask.java
+++ b/src/main/java/com/bisnode/opa/TestRegoCoverageTask.java
@@ -48,7 +48,7 @@ public abstract class TestRegoCoverageTask extends DefaultTask {
                 execSpec.setStandardOutput(outputStream);
             });
 
-            String opaReportsPath = getProject().getRootDir() + "/build/reports/opa";
+            String opaReportsPath = getProject().getBuildDir() + "/reports/opa";
             String output = new String(outputStream.toByteArray(), UTF_8);
             if (new File(opaReportsPath).mkdirs()) {
                 Files.write(Paths.get(opaReportsPath + "/opa-coverage.json"), output.getBytes(UTF_8));


### PR DESCRIPTION
Instead of writing to the project `rootDir`, which is the top-level directory of the whole build, write to the `buildDir`, which is the subproject-specific directory for build artifacts.

In a multi-project Gradle project, I expect the reports to be written to the build directory for that subproject, and not in a directory inside the root project.

Using `buildDir` also honors any customisations that Gradle users have made to their project's `buildDir`.