### PR TITLE
Remove Javadoc warning from build output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,3 +95,9 @@ wrapper {
     gradleVersion = '8.2.1'
     distributionType = Wrapper.DistributionType.ALL
 }
+
+javadoc {
+    options {
+        (it as CoreJavadocOptions).addStringOption("Xdoclint:none", "-quiet")
+    }
+}


### PR DESCRIPTION
Simple configuration to remove all the javadoc warnings about fields/methods/classes/... without comments