### PR TITLE
Upgrade JUnit dependency to 5.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ dependencies {
     implementation 'com.bisnode.opa:opa-test-result-formatter:0.1.2'
 
     testImplementation gradleTestKit()
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+    testImplementation 'org.apiguardian:apiguardian-api:1.1.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testRuntimeOnly files(createClasspathManifest)
 }


### PR DESCRIPTION
Just upgrade to last version of JUnit.

I had to add a dependency to apiguardian to remove warnings, see threads like [this one on JUnit](https://github.com/junit-team/junit5/pull/3193).