### PR TITLE
Make OPA download work for Mac OS X/aarch64

### DIFF
--- a/src/main/java/com/bisnode/opa/configuration/OpaPlatform.java
+++ b/src/main/java/com/bisnode/opa/configuration/OpaPlatform.java
@@ -35,7 +35,7 @@ public enum OpaPlatform {
                 return WINDOWS_AMD64;
             }
         } else if (osName.contains("Mac")) {
-            if (osArch.equals("x86_64")) {
+            if (osArch.equals("x86_64") || osArch.equals("aarch64")) {
                 return MAC_OS_AMD64;
             }
         } else if (osName.contains("Linux")) {


### PR DESCRIPTION
Fix to allow use OPA download on Mac OS X/aarch64