### PR TITLE
Fix gradle deprecation warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,10 @@ plugins {
 group 'com.bisnode.opa'
 version '0.4.2'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Motivation:
Clean up legacy (deprecated) configuration

Modification
Use 'java' extension to avoid warning 'The org.gradle.api.plugins.JavaPluginConvention type has been deprecated'

Doc: https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#java_convention_deprecation