### PR TITLE
Support Windows 10 and 11

### DIFF
--- a/src/main/java/com/bisnode/opa/configuration/OpaPlatform.java
+++ b/src/main/java/com/bisnode/opa/configuration/OpaPlatform.java
@@ -28,8 +28,8 @@ public enum OpaPlatform {
     }
 
     public static OpaPlatform getPlatform() {
-        final String osName = System.getProperty("os.name");
-        final String osArch = System.getProperty("os.arch");
+        final String osName = System.getProperty("os.name").toLowerCase();
+        final String osArch = System.getProperty("os.arch").toLowerCase();
         if (osName.contains("win")) {
             if (osArch.equals("amd64")) {
                 return WINDOWS_AMD64;


### PR DESCRIPTION
On Windows 10/11 os.name is returned as `Windows 10` or `Windows 11`

Therefore the platform check fails with:
```
java.lang.IllegalStateException: Unsupported combination of OS/arch: Windows 11/amd64
        at com.bisnode.opa.configuration.OpaPlatform.getPlatform(OpaPlatform.java:46)
```